### PR TITLE
Fix problem with --dsobject

### DIFF
--- a/mcxToProfile.py
+++ b/mcxToProfile.py
@@ -421,6 +421,8 @@ per-plist basis.""")
         else:
             # ensure capitalization
             manage = options.manage[0].upper() + options.manage[1:].lower()
+    else:
+        manage = None
     if manage == 'Often':
         print >> sys.stderr, \
             ("WARNING: Deploying profiles configured for 'Often' settings "


### PR DESCRIPTION
Ran mcxToProfile using --dsobject but it failed with traceback:

```
./mcxToProfile.py --dsobject /LDAPv3/ldap/ComputerGroups/cgroup --identifier fubar
Traceback (most recent call last):
  File "./mcxToProfile.py", line 467, in <module>
    main()
  File "./mcxToProfile.py", line 424, in main
    if manage == 'Often':
UnboundLocalError: local variable 'manage' referenced before assignment
```

Initialized manage variable to work around. Not sure if this catches all the edge cases that the `manage` variable works with, though. :)