### PR TITLE
added '--defaults' option that gets data with the defaults command

### DIFF
--- a/mcxToProfile.py
+++ b/mcxToProfile.py
@@ -366,8 +366,8 @@ Examples: /Local/Default/Computers/foo
     parser.add_option('--plist', '-p', action="append", metavar='PLIST_FILE',
         help="""Path to a plist to be added as a profile payload.
 Can be specified multiple times.""")
-    parser.add_option('--defaults', action="append", metavar='DEFAULTS_DOMAIN',
-        help="""Default or preferences domain to be added as profile payload.
+    parser.add_option('--defaults', action="append", metavar='APP_ID',
+        help="""Default or preferences application id to be added as profile payload.
 Can be specified multiple times.""")
     parser.add_option('--identifier', '-i',
         action="store",


### PR DESCRIPTION
This adds a `--defaults` option as an alternative to `--plist` and `--dsobject`. Basically this will run the `defaults read` command and create the mobileconfig from that output. That way you do not have to worry where the actual plist is stored and wether `cfprefsd` has already updated. There is an extra option `--currentHost` which will enable the `-currentHost` flag when running the `defaults` command.

Example:

```
./mcxToProfile.py --defaults com.apple.screensaver --identifier com.example.screensaver --currentHost --manage Once
```
