### PR TITLE
Typo in error message

### DIFF
--- a/mcxToProfile.py
+++ b/mcxToProfile.py
@@ -465,7 +465,7 @@ per-plist basis.""")
     if (not options.identifier and not options.identifier_from_profile) or \
     (options.identifier and options.identifier_from_profile):
         parser.print_usage()
-        errorAndExit("Error: identifier must be provided with either '--identifier' or '--identifier_from_profile'")
+        errorAndExit("Error: identifier must be provided with either '--identifier' or '--identifier-from-profile'")
 
     if options.identifier:
         identifier = options.identifier


### PR DESCRIPTION
error message for identifier showed underscores instead of hyphen for identifier-from-profile option

![underscore_typo](https://cloud.githubusercontent.com/assets/1110967/14569614/6708cfa8-0305-11e6-8271-487045bb871f.png)

