### PR TITLE
Make shebang use python3

### DIFF
--- a/mcxToProfile.py
+++ b/mcxToProfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # mcxToProfile.py
 # Simple utility to assist with creating Custom Settings Configuration Profiles


### PR DESCRIPTION
Hi there,

I believe it's been mentioned in a few other issues, but on modern MacOS versions, this change is required for the script to work out-of-the-box (provided the required dependencies are installed).