### PR TITLE
Add install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Administrators who would like to move from MCX-based management to Profiles may 
 
 mcxToProfile should function on OS X 10.5 or greater. It also makes use of Greg Neagle's FoundationPlist library from the Munki project, which provides native plist support via PyObjC. FoundationPlist is licensed under the Apache License, version 2.0.
 
+## Install instructions
+
+* Ensure Xcode is installed on your Mac
+* `git clone https://github.com/timsutton/mcxToProfile.git && cd mcxToProfile`
+* `pip3 install pyobjc`
+* `./mcxToProfile.py --help`
+
 ## Example usage
 
 Here's an example:


### PR DESCRIPTION
Hi there,

The README mentions that this project relies on pyobjc to work, but doesn't explicitly state that this is a dependency that needs to be manually installed, nor how.

Similarly, it's not obvious in the README that this project requires being on MacOS to work (I first tried it on Linux, where I got an explicit `error: PyObjC requires macOS to build` error).

I thought putting together a (very basic) install doc could potentially save some trial and error to future users, so, here it is !
Feel free to change or reorganize it as you see fit, and thanks for this project :) 